### PR TITLE
add a better check for development environment

### DIFF
--- a/app/controllers/rails/routes_controller.rb
+++ b/app/controllers/rails/routes_controller.rb
@@ -1,15 +1,15 @@
 class Rails::RoutesController < ApplicationController
   layout 'rails/routes'
 
-  before_filter :ensure_local
+  before_filter :restrict_to_development
 
   def index
     @routes = Sextant.format_routes
   end
 
   private
-  def ensure_local
-    return false if ActionView::Resolver.caching
+  def restrict_to_development
+    head(:bad_request) unless RAILS_ENV == "development"
   end
 
 end


### PR DESCRIPTION
Leaving the method to test for the environment is a good idea in case someone doesn't put the gem in a development group but I think this might be a better way to check for the environment.
