### PR TITLE
Make a settable controller base class

### DIFF
--- a/app/controllers/rails/routes_controller.rb
+++ b/app/controllers/rails/routes_controller.rb
@@ -1,4 +1,4 @@
-class Rails::RoutesController < ApplicationController
+class Rails::RoutesController < Sextant.controller_base_class
   layout 'rails/routes'
 
   before_filter :ensure_local

--- a/lib/sextant.rb
+++ b/lib/sextant.rb
@@ -2,6 +2,18 @@ require 'rails/application/route_inspector'
 require 'sextant/engine'
 
 module Sextant
+  def self.controller_base_class=(controller_base_class)
+    @controller_base_class = controller_base_class
+  end
+
+  def self.controller_base_class
+    return @controller_base_class if @controller_base_class
+    return ::ApplicationController if defined? ::ApplicationController
+    return ::ActionController::Base if defined? ::ActionController::Base
+
+    raise "Couldn't find a controller base class"
+  end
+
   def self.format_routes(routes = all_routes)
     inspector = Rails::Application::RouteInspector.new
     inspector.format(routes, ENV['CONTROLLER']).join "\n"

--- a/test/controller_base_class_test.rb
+++ b/test/controller_base_class_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class FooTestController < ApplicationController
+end
+
+class ControllerBaseClassTest < ActiveSupport::TestCase
+  test "a specified base class" do
+    Sextant.controller_base_class = FooTestController
+    assert_equal FooTestController, Sextant.controller_base_class
+    Sextant.controller_base_class = nil
+  end
+
+  test "finds a suitable base class when none is specified" do
+    Sextant.controller_base_class = nil
+    assert_equal ::ApplicationController, Sextant.controller_base_class
+  end
+end


### PR DESCRIPTION
Some people may not have an ApplicationController, so allow
setting of it via Sextant.controller_base_class=

The implementation is a bit crude but works.  If there's a better
way than returning from defined? checks that would be preferred.
